### PR TITLE
More layout bugs

### DIFF
--- a/src/features/read/Read.tsx
+++ b/src/features/read/Read.tsx
@@ -9,6 +9,7 @@ import {
   selectPageNumber,
   selectOnCredits,
   selectCanPageForward,
+  selectQuestionStatus,
 } from "./readSlice";
 import BookPage from "./components/BookPage";
 import CenteredLayout from "layouts/Centered";
@@ -21,6 +22,7 @@ function Read() {
   const page = useSelector(selectPage);
   const onCreditsPage = useSelector(selectOnCredits);
   const canPageForward = useSelector(selectCanPageForward);
+  const questionStatus = useSelector(selectQuestionStatus);
 
   if (!book) {
     // TODO: Use an effect hook or something to make sure that we get a warning to sentry
@@ -44,6 +46,7 @@ function Read() {
   return (
     <BookPageLayout
       backgroundImage={book.fields.pageBackground}
+      divider={questionStatus !== "NOT_QUESTION"}
       pageForward={canPageForward ? () => dispatch(nextPage()) : undefined}
       pageNumber={pageNumber}
     >

--- a/src/features/select-book/components/Bookshelf.tsx
+++ b/src/features/select-book/components/Bookshelf.tsx
@@ -14,7 +14,7 @@ function SelectBook() {
   return (
     <Container>
       <h1>Bookshelf</h1>
-      <CardDeck>
+      <CardDeck className="justify-content-center">
         {choices.map((c) => (
           <BookCard book={c} />
         ))}
@@ -32,7 +32,9 @@ function BookCard({ book }: BookCardProps) {
   const dispatch = useDispatch();
   const cover = book.fields.cover;
   return (
-    <Card>
+    <Card
+      style={{ minWidth: "300px", marginBottom: "1rem", maxWidth: "350px" }}
+    >
       {cover && (
         <Card.Img
           alt={book.fields.title}

--- a/src/features/setup-device/SetupDevice.tsx
+++ b/src/features/setup-device/SetupDevice.tsx
@@ -21,7 +21,7 @@ function NewSession() {
   };
 
   return (
-    <CenteredLayout>
+    <CenteredLayout vertical={false}>
       <div>
         <h1>First, let's set up this device</h1>
         <p>

--- a/src/layouts/BookPage.tsx
+++ b/src/layouts/BookPage.tsx
@@ -19,6 +19,7 @@ interface OnFinishBook {
 interface BookPageLayoutProps {
   backgroundImage?: Asset;
   children?: React.ReactNode;
+  divider?: boolean;
   pageNumber: number;
   pageForward?: OnClick;
   finishBook?: OnFinishBook;
@@ -27,6 +28,7 @@ interface BookPageLayoutProps {
 function BookPageLayout({
   backgroundImage,
   children,
+  divider,
   finishBook,
   pageForward,
   pageNumber,
@@ -91,7 +93,7 @@ function BookPageLayout({
       >
         Page {pageNumber + 1}
       </p>
-      <div className={styles.divider} />
+      {divider === true && <div className={styles.divider} />}
     </Container>
   );
 }

--- a/src/layouts/BookPage.tsx
+++ b/src/layouts/BookPage.tsx
@@ -47,13 +47,17 @@ function BookPageLayout({
       </div>
 
       {!finishBook && (
-        <div className={styles.nextPage}>
+        <div
+          className={cn("w-100 d-flex justify-content-end", {
+            [styles.bottomCenterWithMargin]: isScrollable !== true,
+          })}
+          style={{ paddingRight: "1rem" }}
+        >
           <Button
-            block
             className="btn-xl"
             disabled={!pageForward}
             onClick={pageForward}
-            style={{ visibility: pageForward ? "visible" : "hidden" }}
+            style={{ display: pageForward ? "block" : "none" }}
           >
             Next page
           </Button>

--- a/src/layouts/book-page.module.css
+++ b/src/layouts/book-page.module.css
@@ -14,12 +14,10 @@
   bottom: 0;
 }
 
-.nextPage {
+.bottomCenterWithMargin {
   position: absolute;
   bottom: 0;
-  right: 0;
   margin-bottom: 1rem;
-  margin-right: 1rem;
 }
 
 .finishBook {


### PR DESCRIPTION
* Minimum card width during book selection
* Allow for scrolling overflowed content during device setup (esp. important for landscape phone)
* Remove divider from credits and narrative pages
* Prevent Next Page button from overlapping content in some cases