### PR TITLE
Use LongText when it is provided

### DIFF
--- a/src/features/read/components/Prompt.tsx
+++ b/src/features/read/components/Prompt.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { IPrompt } from "types/generated/contentful";
+import PromptModel from "models/Prompt";
 
 function Prompt({ prompt }: PromptProps) {
   return (
@@ -7,7 +8,7 @@ function Prompt({ prompt }: PromptProps) {
       className="mb-0 text-center"
       style={{ fontSize: "2.5rem", zIndex: 1000 }}
     >
-      {prompt.fields.text}
+      {PromptModel.getText(prompt)}
     </p>
   );
 }

--- a/src/models/Prompt.ts
+++ b/src/models/Prompt.ts
@@ -1,0 +1,10 @@
+import { IPrompt } from "types/generated/contentful";
+
+class Prompt {
+  static getText(prompt: IPrompt): string {
+    const { text, longText } = prompt.fields;
+    return longText ? longText : text;
+  }
+}
+
+export default Prompt;

--- a/src/models/__tests__/Prompt.ts
+++ b/src/models/__tests__/Prompt.ts
@@ -1,0 +1,50 @@
+import Prompt from "../Prompt";
+import { IPrompt, IPromptFields } from "types/generated/contentful";
+
+describe("#getText", () => {
+  it("should return the LongText field when it has a value", () => {
+    const prompt = createPrompt({
+      text: "I am short!",
+      longText: "And I am very very long (potentially)",
+    });
+    expect(Prompt.getText(prompt)).toBe(
+      "And I am very very long (potentially)"
+    );
+  });
+
+  it("should return the text field when LongText is empty string", () => {
+    const prompt = createPrompt({ text: "I am short", longText: "" });
+    expect(Prompt.getText(prompt)).toBe("I am short");
+  });
+
+  it("should return the text field when LongText is undefined", () => {
+    const prompt = createPrompt({ text: "I am short" });
+    expect(Prompt.getText(prompt)).toBe("I am short");
+  });
+});
+
+function createPrompt(fields: IPromptFields): IPrompt {
+  return {
+    fields: fields,
+    sys: {
+      id: "XYZ",
+      type: "prompt",
+      createdAt: "now",
+      updatedAt: "now",
+      locale: "en-us",
+      contentType: {
+        sys: {
+          id: "prompt",
+          linkType: "ContentType",
+          type: "Link",
+        },
+      },
+    },
+    toPlainObject() {
+      return fields;
+    },
+    update() {
+      return Promise.resolve(createPrompt(fields));
+    },
+  };
+}


### PR DESCRIPTION
This change applies for any text field: Page narrative, Question narrative, and Question prompt. (Although I expect it will not be used for question prompts).

All text in the book configured in Contentful is done using a Text content type. The text field is the title of the content type and is the default place to place text. However, if you need more than 256 characters, you can drop down into the LongText field. The app will now render the long-text field when available. 