### PR TITLE
Put feedback at top in place of question text

### DIFF
--- a/src/features/read/components/Question.tsx
+++ b/src/features/read/components/Question.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import cn from "classnames";
 import { useDispatch, useSelector } from "react-redux";
 import Button from "react-bootstrap/Button";
 import { Asset } from "contentful";
@@ -9,7 +8,6 @@ import Prompt from "./Prompt";
 
 import {
   chooseAnswerAsync,
-  selectAnswer,
   selectQuestionStatus,
   selectPrompt,
   selectChoice,
@@ -41,33 +39,20 @@ function Choice({ choice, questionId }: ChoiceProps) {
   const dispatch = useDispatch();
 
   const status = useSelector(selectQuestionStatus);
-  const answer = useSelector(selectAnswer);
 
   const selectStimulus = (stimulusId: string) => {
     dispatch(chooseAnswerAsync({ questionId, stimulusId }));
-  };
-
-  const decorate = (stimulusId: string) => {
-    if (
-      (status === "CORRECT" || status === "WRONG") &&
-      stimulusId === answer?.stimulusId
-    ) {
-      return status;
-    }
-    return false;
   };
 
   const disabled = status !== "UNANSWERED";
   return (
     <>
       <Stimulus
-        decorate={decorate(choice.fields.stimulusA.sys.id)}
         disabled={disabled}
         onClick={selectStimulus}
         stimulus={choice.fields.stimulusA}
       />
       <Stimulus
-        decorate={decorate(choice.fields.stimulusB.sys.id)}
         disabled={disabled}
         onClick={selectStimulus}
         stimulus={choice.fields.stimulusB}
@@ -82,7 +67,6 @@ interface ChoiceProps {
 }
 
 interface StimulusProps {
-  decorate?: "CORRECT" | "WRONG" | false;
   disabled: boolean;
   onClick: OnStimulusClick;
   stimulus: Asset;
@@ -97,14 +81,11 @@ interface OnStimulusClick {
 // The stimulus should be able to use it's stimulus ID and then ask more about itself of state
 // e.g., - am I disabled? am I right / wrong?
 
-function Stimulus({ decorate, disabled, onClick, stimulus }: StimulusProps) {
-  const cx = cn("d-flex flex-column justify-content-between", styles.stimulus, {
-    [styles.stimulusCorrect]: decorate === "CORRECT",
-    [styles.stimulusWrong]: decorate === "WRONG",
-  });
-
+function Stimulus({ disabled, onClick, stimulus }: StimulusProps) {
   return (
-    <div className={cx}>
+    <div
+      className={`d-flex flex-column justify-content-between ${styles.stimulus}`}
+    >
       <img alt={stimulus.fields.description} src={stimulus.fields.file.url} />
       <Button
         className="btn-xl"

--- a/src/features/read/components/Question.tsx
+++ b/src/features/read/components/Question.tsx
@@ -11,6 +11,7 @@ import {
   selectQuestionStatus,
   selectPrompt,
   selectChoice,
+  Grade,
 } from "../readSlice";
 
 import styles from "./question.module.css";
@@ -20,18 +21,42 @@ interface QuestionProps {
 }
 
 function Question({ question }: QuestionProps) {
-  const narrative = question.fields.narrative;
-  const questionPrompt = useSelector(selectPrompt);
+  const status = useSelector(selectQuestionStatus);
   const choice = useSelector(selectChoice);
 
   return (
     <>
-      {narrative && <Prompt prompt={narrative} />}
-      {questionPrompt && <Prompt prompt={questionPrompt} />}
+      {status === "UNANSWERED" || status === "NOT_QUESTION" ? (
+        <QuestionText question={question} />
+      ) : (
+        <Feedback grade={status} />
+      )}
       <div className="w-100 d-flex align-items-center justify-content-around">
         {choice && <Choice choice={choice} questionId={question.sys.id} />}
       </div>
     </>
+  );
+}
+
+function QuestionText({ question }: { question: IQuestion }) {
+  const narrative = question.fields.narrative;
+  const questionPrompt = useSelector(selectPrompt);
+  return (
+    <>
+      {narrative && <Prompt prompt={narrative} />}
+      {questionPrompt && <Prompt prompt={questionPrompt} />}
+    </>
+  );
+}
+
+function Feedback({ grade }: { grade: Grade }) {
+  return (
+    <p
+      className="mb-0 text-center"
+      style={{ fontSize: "2.5rem", zIndex: 1000 }}
+    >
+      {grade}
+    </p>
   );
 }
 
@@ -75,11 +100,6 @@ interface StimulusProps {
 interface OnStimulusClick {
   (stimulusId: string): void;
 }
-
-// TODO: Stimulus should probably be own file
-// When it is its own file that will make me want to rethink the data passing
-// The stimulus should be able to use it's stimulus ID and then ask more about itself of state
-// e.g., - am I disabled? am I right / wrong?
 
 function Stimulus({ disabled, onClick, stimulus }: StimulusProps) {
   return (

--- a/src/features/read/components/Question.tsx
+++ b/src/features/read/components/Question.tsx
@@ -58,7 +58,7 @@ function Feedback({ grade }: { grade: Grade }) {
         [styles.wrong]: grade === "WRONG",
       })}
     >
-      {grade}
+      {grade === "CORRECT" ? "Correct! ✅" : "Sorry, that's not right. ⛔️"}
     </p>
   );
 }

--- a/src/features/read/components/Question.tsx
+++ b/src/features/read/components/Question.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import cn from "classnames";
 import { useDispatch, useSelector } from "react-redux";
 import Button from "react-bootstrap/Button";
 import { Asset } from "contentful";
@@ -52,8 +53,10 @@ function QuestionText({ question }: { question: IQuestion }) {
 function Feedback({ grade }: { grade: Grade }) {
   return (
     <p
-      className="mb-0 text-center"
-      style={{ fontSize: "2.5rem", zIndex: 1000 }}
+      className={cn("mb-0 text-center", {
+        [styles.correct]: grade === "CORRECT",
+        [styles.wrong]: grade === "WRONG",
+      })}
     >
       {grade}
     </p>

--- a/src/features/read/components/question.module.css
+++ b/src/features/read/components/question.module.css
@@ -6,11 +6,3 @@
   max-width: 100%;
   height: auto;
 }
-
-.stimulusCorrect {
-  border: 0.125rem solid var(--success);
-}
-
-.stimulusWrong {
-  border: 0.125rem solid var(--danger);
-}

--- a/src/features/read/components/question.module.css
+++ b/src/features/read/components/question.module.css
@@ -6,3 +6,17 @@
   max-width: 100%;
   height: auto;
 }
+
+.correct,
+.wrong {
+  font-size: 2.5rem;
+  z-index: 1000;
+}
+
+.correct {
+  color: var(--success);
+}
+
+.wrong {
+  color: var(--danger);
+}

--- a/src/features/read/readSlice.ts
+++ b/src/features/read/readSlice.ts
@@ -286,7 +286,7 @@ export const selectCanPageForward = (state: RootState): boolean => {
   return questionStatus !== "UNANSWERED";
 };
 
-type Grade = "CORRECT" | "WRONG";
+export type Grade = "CORRECT" | "WRONG";
 type QuestionStatus = "NOT_QUESTION" | "UNANSWERED" | Grade;
 
 function randomMode(): Mode {


### PR DESCRIPTION
**Put feedback at top in place of question text**

# Work done
* Remove border from stimuli
* After question is answered, remove the narrative and question prompt and replace it with "Correct" or "Sorry" feedback message

# Benefits
* Improves the use of space, which is at a premium especially on phones
* Prevents the border color from getting lost in the page background