### PR TITLE
🐛 Do not crash when a book is missing a cover image

### DIFF
--- a/src/features/select-book/components/Bookshelf.tsx
+++ b/src/features/select-book/components/Bookshelf.tsx
@@ -35,7 +35,7 @@ function BookCard({ book }: BookCardProps) {
     <Card
       style={{ minWidth: "300px", marginBottom: "1rem", maxWidth: "350px" }}
     >
-      {cover && (
+      {cover && cover.fields && (
         <Card.Img
           alt={book.fields.title}
           src={cover.fields.file.url}


### PR DESCRIPTION
I was already doing a check for the existence of the cover. However, the cover is not guaranteed to have fields. 