### PR TITLE
Treatment-specific narrative pages

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -43,11 +43,6 @@ export interface AnswerDocument {
   // TODO: choseCorrectStimulus
 }
 
-interface Auditable {
-  createdAt: firebase.firestore.FieldValue;
-  deploy: string;
-}
-
 function getInsertAuditFields() {
   return {
     createdAt: firebase.firestore.FieldValue.serverTimestamp(),

--- a/src/features/read/components/Page.tsx
+++ b/src/features/read/components/Page.tsx
@@ -1,13 +1,19 @@
 import React from "react";
+import { useSelector } from "react-redux";
 import { IPage } from "types/generated/contentful";
+import PageModel from "models/Page";
+import { selectTreatment } from "features/setup-device/setupDeviceSlice";
 import Prompt from "./Prompt";
 import styles from "./page.module.css";
 
 function Page({ page }: PageProps) {
   const picture = page.fields.picture;
+  const treatment = useSelector(selectTreatment);
+  const prompt = treatment ? PageModel.getPrompt(page, treatment) : null;
+
   return (
     <>
-      <Prompt prompt={page.fields.narrative} />
+      {prompt && <Prompt prompt={prompt} />}
       {picture ? (
         <div className={styles.pictureContainer}>
           <img

--- a/src/models/Page.ts
+++ b/src/models/Page.ts
@@ -1,9 +1,24 @@
-import { IPage } from "types/generated/contentful";
+import { IPage, IPrompt } from "types/generated/contentful";
+import { Treatment } from "features/setup-device/setupDeviceSlice";
 
 class Page {
   static getAudio(page: IPage): string[] {
     const promptAudio = page.fields.narrative.fields.audio?.fields.file.url;
     return promptAudio ? [promptAudio] : [];
+  }
+
+  static getPrompt(page: IPage, treatment: Treatment): IPrompt | null {
+    switch (treatment) {
+      case "mixed": {
+        return page.fields.narrative;
+      }
+      case "number": {
+        return page.fields.numberNarrative || null;
+      }
+      case "size": {
+        return page.fields.sizeNarrative || null;
+      }
+    }
   }
 }
 

--- a/src/models/Page.ts
+++ b/src/models/Page.ts
@@ -10,6 +10,9 @@ class Page {
   static getPrompt(page: IPage, treatment: Treatment): IPrompt | null {
     switch (treatment) {
       case "mixed": {
+        // Originally, the page only had a single narrative field.
+        // When we added fields that are specific to the treatment,
+        // the original field was repurposes to be the "mixed treatment" narrative field
         return page.fields.narrative;
       }
       case "number": {

--- a/src/types/generated/contentful.d.ts
+++ b/src/types/generated/contentful.d.ts
@@ -109,11 +109,17 @@ export interface IPageFields {
   /** Internal Title */
   internalTitle?: string | undefined;
 
-  /** Narrative */
-  narrative: IPrompt;
-
   /** Picture */
   picture?: Asset | undefined;
+
+  /** Number Narrative */
+  numberNarrative?: IPrompt | undefined;
+
+  /** Mixed Narrative */
+  narrative: IPrompt;
+
+  /** Size Narrative */
+  sizeNarrative?: IPrompt | undefined;
 }
 
 /** A page of an eBook containing content, but no question.  */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,8 @@
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
     "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
Added two new fields to the Page content type
* Number Narrative
* Size Narrative

Renamed the "narrative" field to "Mixed Narrative."

Added a light bit of logic to take a page and a treatment and return the correct narrative.