### PR TITLE
Mixed treatment constraint: Only up to two in a row of the same mode

### DIFF
--- a/src/features/read/mixed-treatment.test.ts
+++ b/src/features/read/mixed-treatment.test.ts
@@ -1,0 +1,112 @@
+import { Mode, Difficulty } from "models/constants";
+import { Answer } from "./readSlice";
+import { nextMode } from "./mixed-treatment";
+
+describe("#nextMode", () => {
+  it("should pick a random mode if there is not enough history", () => {
+    expectToBeRandom([]);
+    expectToBeRandom(makeAnswers(["number"]));
+  });
+
+  it("should pick a random mode if the latest two modes are not repeats two of the same in a row", () => {
+    expectToBeRandom(makeAnswers(["number", "size"]));
+    expectToBeRandom(
+      makeAnswers([
+        "number",
+        "size",
+        // only last two should be relevant
+        "size",
+        "number",
+      ])
+    );
+    expectToBeRandom(
+      makeAnswers([
+        "number",
+        "number",
+        "size",
+        "size",
+        "number",
+        "size",
+        "number",
+        "number",
+        "size",
+        // These last two should be the only relevant ones
+        "size",
+        "number",
+      ])
+    );
+  });
+
+  it("should pick the opposite mode if there are two in a row that are the same", () => {
+    expect(nextMode(makeAnswers(["size", "size"]))).toBe("number");
+    expect(nextMode(makeAnswers(["number", "number"]))).toBe("size");
+
+    expect(
+      nextMode(
+        makeAnswers([
+          "size",
+          "size",
+          "number",
+          "number",
+          "size",
+          "number",
+          "number",
+          "size",
+          "size",
+        ])
+      )
+    ).toBe("number");
+
+    expect(
+      nextMode(
+        makeAnswers([
+          "number",
+          "size",
+          "number",
+          "size",
+          "size",
+          "number",
+          "number",
+          "size",
+          "size",
+          "number",
+          "number",
+        ])
+      )
+    ).toBe("size");
+  });
+});
+
+function expectToBeRandom(history: Answer[]) {
+  const actuals: Mode[] = [];
+
+  for (let i = 0; i < 100; i++) {
+    actuals.push(nextMode(history));
+  }
+
+  expect(actuals).toContain<Mode>("number");
+  expect(actuals).toContain<Mode>("size");
+}
+
+function makeAnswers(modeHistory: Mode[]): Answer[] {
+  function getDifficulty(index: number): Difficulty {
+    if (index <= 5) {
+      return "easy";
+    }
+    if (index <= 10) {
+      return "medium";
+    }
+    return "hard";
+  }
+
+  return modeHistory.map((m, i) => {
+    return {
+      mode: m,
+      // These fields are not relevant to picking the next mode, so it's fine to fake them
+      difficulty: getDifficulty(i),
+      pageNumber: i + 1,
+      questionId: `q-${i}`,
+      stimulusId: `s-${i}`,
+    };
+  });
+}

--- a/src/features/read/mixed-treatment.ts
+++ b/src/features/read/mixed-treatment.ts
@@ -1,0 +1,20 @@
+import { last } from "lib/array";
+import { flipCoin } from "lib/math/random";
+import { Mode } from "models/constants";
+import { Answer } from "./readSlice";
+
+export function nextMode(history: Answer[]): Mode {
+  if (history.length >= 2) {
+    const modeHistory = history.map((h) => h.mode);
+    const latest = last(modeHistory, 2);
+    if (latest[0] === latest[1]) {
+      return oppositeMode(latest[0]);
+    }
+  }
+
+  return flipCoin("number", "size");
+}
+
+function oppositeMode(mode: Mode): Mode {
+  return mode === "number" ? "size" : "number";
+}


### PR DESCRIPTION
To make sure that children in the mixed mode really get a good mix of number and size questions, cap the "randomness" to up to two in a row of the same mode.